### PR TITLE
Fix import-time errors blocking eval on olm2vec

### DIFF
--- a/src/constant/dataset_hf_path.py
+++ b/src/constant/dataset_hf_path.py
@@ -1,3 +1,6 @@
+import os
+from src.constant.dataset_hflocal_path import BASE_RAW_DATA_DIR
+
 # (repo, subset, split)
 EVAL_DATASET_HF_PATH = {
     # Video-RET

--- a/src/data/eval_dataset/__init__.py
+++ b/src/data/eval_dataset/__init__.py
@@ -30,7 +30,8 @@ from .image_t2i_eval import load_image_t2i_dataset
 from .image_i2t_eval import load_image_i2t_dataset
 from .image_i2i_vg_dataset import load_image_i2i_vg_dataset
 from .mcmr_dataset import load_mcmr_dataset
-from .mscoco_cmret import load_mscoco_cmret_dataset
+# mscoco_cmret module is absent on this olm2vec commit; not needed for tool/memory eval
+# from .mscoco_cmret import load_mscoco_cmret_dataset
 
 # VisDoc
 from .vidore_dataset import load_vidore_dataset

--- a/src/model/model.py
+++ b/src/model/model.py
@@ -729,6 +729,7 @@ class MMEBModel(nn.Module):
                 torch_dtype=torch.bfloat16,
                 low_cpu_mem_usage=True,
                 config=config,
+                trust_remote_code=True,
                             )
         elif model_args.model_backbone == PHI3V:
             config = AutoConfig.from_pretrained(model_args.model_name, trust_remote_code=True)

--- a/src/utils/vision_utils/video_transforms.py
+++ b/src/utils/vision_utils/video_transforms.py
@@ -6,7 +6,11 @@ import requests
 import torchvision
 from PIL import Image
 from torchvision.datasets.folder import IMG_EXTENSIONS, pil_loader
-from torchvision.io import write_video
+try:
+    from torchvision.io import write_video
+except ImportError:  # torchvision >=0.26 removed video IO; not needed for text/image eval
+    def write_video(*args, **kwargs):
+        raise RuntimeError("torchvision.io.write_video is unavailable in this torchvision version")
 from . import video_transforms
 
 VID_EXTENSIONS = (".mp4", ".avi", ".mov", ".mkv")

--- a/src/utils/vision_utils/vision_utils.py
+++ b/src/utils/vision_utils/vision_utils.py
@@ -11,7 +11,11 @@ import torchvision
 import torchvision.transforms as transforms
 from PIL import Image
 from torchvision.datasets.folder import IMG_EXTENSIONS, pil_loader
-from torchvision.io import write_video
+try:
+    from torchvision.io import write_video
+except ImportError:  # torchvision >=0.26 removed video IO; not needed for text/image eval
+    def write_video(*args, **kwargs):
+        raise RuntimeError("torchvision.io.write_video is unavailable in this torchvision version")
 from torchvision.utils import save_image
 
 from src.utils.vision_utils import video_transforms


### PR DESCRIPTION
The eval entrypoint eagerly imports every dataset loader, so a handful of import-time bugs in unrelated modules prevented eval.py from running at all (e.g. tool/memory agent tasks). Minimal fixes:

- vision_utils/{video_transforms,vision_utils}.py: guard `from torchvision.io import write_video`; torchvision >=0.26 removed video IO, and it is unused for text/image eval.
- constant/dataset_hf_path.py: add missing `import os` and import of BASE_RAW_DATA_DIR (both were used but neither imported -> NameError).
- data/eval_dataset/__init__.py: comment out import of the absent `mscoco_cmret` module.
- model/model.py: pass `trust_remote_code=True` to AutoModel.from_pretrained for the NVOMNIEMBED backbone (omni-embed-nemotron ships custom remote code; without it the load hangs on an interactive prompt / fails in batch).