### PR TITLE
fix(processor): preserve text in LCO multimodal promptsUpdate process…

### DIFF
--- a/src/model/processor.py
+++ b/src/model/processor.py
@@ -2088,7 +2088,7 @@ def process_input_text(instruction, model_backbone, text=None, add_video_token=F
             suffix = "\nSummarize the above audio in one word:"
         else:
             suffix = "\nSummarize the above text in one word:"
-        if text and not add_image_token and not add_video_token:
+        if text:
             return text + suffix
         return suffix
 


### PR DESCRIPTION
Remove the image/video conditions that caused process_input_text to discard question text when add_image_token or add_video_token was enabled.

Now, whenever text is provided, it is prepended to the corresponding image, video, audio, or text summarization suffix. This fixes the missing-question issue in LCO Image-QA evaluation.